### PR TITLE
Revert "Create CODEOWNERS"

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,0 @@
-*                       @FushuWang @yaalsn @streamnative/cloud


### PR DESCRIPTION
Reverts streamnative/community-operators-prod#1. The upstream repo only allows adding files into directory `operators`.